### PR TITLE
Don’t resend same led matrix if it’s still being displayed

### DIFF
--- a/nuimo/src/main/kotlin/com/senic/nuimo/NuimoBluetoothController.kt
+++ b/nuimo/src/main/kotlin/com/senic/nuimo/NuimoBluetoothController.kt
@@ -71,8 +71,8 @@ class NuimoBluetoothController(bluetoothDevice: BluetoothDevice, context: Contex
         //TODO: Start timeout that disconnects if services are not discovered and descriptors are not written in time
     }
 
-    override fun displayLedMatrix(matrix: NuimoLedMatrix, displayInterval: Double) {
-        matrixWriter?.write(matrix, displayInterval)
+    override fun displayLedMatrix(matrix: NuimoLedMatrix, displayInterval: Double, resendsSameMatrix: Boolean) {
+        matrixWriter?.write(matrix, displayInterval, resendsSameMatrix)
     }
 
     private inner class GattCallback: BluetoothGattCallback() {
@@ -204,9 +204,19 @@ private class LedMatrixWriter(gatt: BluetoothGatt, matrixCharacteristic: Bluetoo
     private var writeQueue = writeQueue
     private var currentMatrix: NuimoLedMatrix? = null
     private var currentMatrixDisplayIntervalSecs = 0.0
+    private var lastWrittenMatrix: NuimoLedMatrix? = null
+    private var lastWrittenMatrixTime = 0L
+    private var lastWrittenMatrixDisplayInterval = 0.0
     private var writeMatrixOnWriteResponseReceived = false
 
-    fun write(matrix: NuimoLedMatrix, displayInterval: Double) {
+    fun write(matrix: NuimoLedMatrix, displayInterval: Double, resendsSameMatrix: Boolean) {
+        if (!resendsSameMatrix &&
+                matrix == lastWrittenMatrix &&
+                (lastWrittenMatrixDisplayInterval > 0 &&
+                System.currentTimeMillis() < (lastWrittenMatrixTime + lastWrittenMatrixDisplayInterval))) {
+            return
+        }
+
         currentMatrix = matrix
         currentMatrixDisplayIntervalSecs = displayInterval
 
@@ -221,6 +231,10 @@ private class LedMatrixWriter(gatt: BluetoothGatt, matrixCharacteristic: Bluetoo
         writeQueue.push {
             matrixCharacteristic.value = gattBytes
             gatt.writeCharacteristic(matrixCharacteristic)
+
+            lastWrittenMatrix = currentMatrix
+            lastWrittenMatrixTime = System.currentTimeMillis()
+            lastWrittenMatrixDisplayInterval = currentMatrixDisplayIntervalSecs * 1000
         }
     }
 

--- a/nuimo/src/main/kotlin/com/senic/nuimo/NuimoController.kt
+++ b/nuimo/src/main/kotlin/com/senic/nuimo/NuimoController.kt
@@ -25,7 +25,15 @@ abstract class NuimoController(address: String) {
 
     abstract fun disconnect()
 
-    abstract fun displayLedMatrix(matrix: NuimoLedMatrix, displayInterval: Double = defaultMatrixDisplayInterval)
+    fun displayLedMatrix(matrix: NuimoLedMatrix) {
+        displayLedMatrix(matrix, defaultMatrixDisplayInterval, false)
+    }
+
+    fun displayLedMatrix(matrix: NuimoLedMatrix, displayInterval: Double) {
+        displayLedMatrix(matrix, displayInterval, false)
+    }
+
+    abstract fun displayLedMatrix(matrix: NuimoLedMatrix, displayInterval: Double, resendsSameMatrix: Boolean)
 
     fun addControllerListener(controllerListener: NuimoControllerListener) {
         listeners.add(controllerListener)

--- a/nuimo/src/main/kotlin/com/senic/nuimo/NuimoController.kt
+++ b/nuimo/src/main/kotlin/com/senic/nuimo/NuimoController.kt
@@ -26,11 +26,11 @@ abstract class NuimoController(address: String) {
     abstract fun disconnect()
 
     fun displayLedMatrix(matrix: NuimoLedMatrix) {
-        displayLedMatrix(matrix, defaultMatrixDisplayInterval, false)
+        displayLedMatrix(matrix, defaultMatrixDisplayInterval, true)
     }
 
     fun displayLedMatrix(matrix: NuimoLedMatrix, displayInterval: Double) {
-        displayLedMatrix(matrix, displayInterval, false)
+        displayLedMatrix(matrix, displayInterval, true)
     }
 
     abstract fun displayLedMatrix(matrix: NuimoLedMatrix, displayInterval: Double, resendsSameMatrix: Boolean)


### PR DESCRIPTION
Add write matrix argument that optionally prevents a matrix from being sent again if its still being displayed
