### PR TITLE
Catch exception thrown by bug in Android 5.0

### DIFF
--- a/nuimo/src/main/kotlin/com/senic/nuimo/NuimoDiscoveryManager.kt
+++ b/nuimo/src/main/kotlin/com/senic/nuimo/NuimoDiscoveryManager.kt
@@ -65,7 +65,12 @@ class NuimoDiscoveryManager(context: Context) {
 
     fun stopDiscovery() {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-            bluetoothAdapter?.bluetoothLeScanner?.stopScan(scanCallbackApi21)
+            try {
+                bluetoothAdapter?.bluetoothLeScanner?.stopScan(scanCallbackApi21)
+            }
+            catch (ignore: NullPointerException) {
+                // Catches exception caused by a bug in Android 5.0: https://code.google.com/p/android/issues/detail?id=160503
+            }
         }
         else {
             @Suppress("DEPRECATION")


### PR DESCRIPTION
Bug report: https://code.google.com/p/android/issues/detail?id=160503
Also related: AltBeacon/android-beacon-library#219
